### PR TITLE
Fix: NTP Blocked By PF

### DIFF
--- a/etc/ntpd.conf
+++ b/etc/ntpd.conf
@@ -1,0 +1,10 @@
+# $OpenBSD: ntpd.conf,v 1.16 2019/11/06 19:04:12 deraadt Exp $
+#
+# See ntpd.conf(5) and /etc/examples/ntpd.conf
+constraint from "https://www.cloudflare.com/"
+
+servers pool.ntp.org
+servers time.cloudflare.com
+
+listen on 127.0.0.1
+listen on 172.16.0.1

--- a/etc/pf.conf
+++ b/etc/pf.conf
@@ -20,7 +20,7 @@ match in all scrub (no-df random-id max-mss 1440)
 
 # Defaults
 block all
-antispoof quick for { lo $lan }
+antispoof quick for { lo $lan $wan }
 
 # Tables for ICMP abusers
 table <icmp_abusers> persist
@@ -44,6 +44,10 @@ pass out on $wan proto tcp to port 853
 pass in on $wan inet proto icmp icmp-type { echorep, timex, unreach } keep state \
         (max-src-conn-rate 5/10, overload <icmp_abusers>)
 block in quick on $wan from <icmp_abusers> label "block icmp abusers"
+
+## NTP
+pass out on $wan proto udp from any to port 123 keep state
+pass in on $lan proto udp from any to ($lan) port 123 keep state
 
 ## SSH
 block in log on $wan proto tcp from any to ($wan) port 22 flags S/SA 


### PR DESCRIPTION
- Allow NTP outbound, and let Pirewall serve NTP to LAN
    - Modify pf.conf to allow port 123 outbound from WAN interface
    - Modify pf.conf to allow port 123 inbound on LAN interface
- Modify ntpd.conf for better security
    - Remove google.com from list of servers
    - Add time.cloudflare.com to list of servers
    - Add https://www.cloudflare.com as a constraint
    - Set ntpd to listen for both localhost and the LAN