### PR TITLE
Feat: Additional security enhancements

### DIFF
--- a/etc/pf.conf
+++ b/etc/pf.conf
@@ -3,27 +3,25 @@ wan="bwfm0"
 lan="bse0"
 lan_net = "172.16.0.0/30"
 
-# Defaults & hygiene
+# Set global behaviours
 set block-policy drop
 set skip on lo
 set state-policy if-bound
+set limit { states 1000, src-nodes 2000, frags 5000 } 
+set loginterface $wan
 
-# State table protections
-set limit states 1000
-set limit src-nodes 2000
-set limit frags 5000
-set timeout adaptive.start 5000
-set timeout adaptive.end 10000
+# Set default behaviours
+block drop log all
+antispoof log quick for { lo $lan $wan }
+
+# Tables and Blocklists
+table <badactors> persist
+
+# Always drop a source if in these tables
+block quick from <badactors> to any
 
 # Normalise traffic
-match in all scrub (no-df random-id max-mss 1440)
-
-# Defaults
-block all
-antispoof quick for { lo $lan $wan }
-
-# Tables for ICMP abusers
-table <icmp_abusers> persist
+match in all scrub (reassemble tcp no-df random-id max-mss 1440)
 
 # NAT policy (LAN -> WAN)
 match out on $wan from $lan_net to any nat-to ($wan) label "nat"
@@ -38,12 +36,12 @@ pass out on $wan proto udp from port 68 to port 67 keep state
 pass in on $wan proto udp from port 67 to port 68 keep state
 
 ## DNS
-pass out on $wan proto tcp to port 853
+pass out on $wan proto tcp to port 853 \
+        keep state (max-src-conn-rate 100/10, max-src-conn 200)
 
 ## ICMP
 pass in on $wan inet proto icmp icmp-type { echorep, timex, unreach } keep state \
-        (max-src-conn-rate 5/10, overload <icmp_abusers>)
-block in quick on $wan from <icmp_abusers> label "block icmp abusers"
+        (max-src-conn-rate 5/10, overload <badactors>)
 
 ## NTP
 pass out on $wan proto udp from any to port 123 keep state
@@ -51,7 +49,8 @@ pass in on $lan proto udp from any to ($lan) port 123 keep state
 
 ## SSH
 block in log on $wan proto tcp from any to ($wan) port 22 flags S/SA 
-pass in log on $lan proto tcp from any to ($lan) port 22 flags S/SA keep state label "lan-ssh"
+pass in quick log on $lan proto tcp from ($lan) to ($lan) port 22 flags S/SA  \
+        keep state (max-src-conn 10, max-src-conn-rate 10/10, overload <badactors>) label "lan-ssh"
 
 # LAN policy
 pass in on $lan from $lan_net to any keep state

--- a/etc/ssh/sshd_config
+++ b/etc/ssh/sshd_config
@@ -1,0 +1,95 @@
+#	$OpenBSD: sshd_config,v 1.105 2024/12/03 14:12:47 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+AddressFamily inet 
+ListenAddress 172.16.0.1
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+PermitRootLogin no
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to "no" here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to "no" to disable keyboard-interactive authentication.  Depending on
+# the system's configuration, this may involve passwords, challenge-response,
+# one-time passwords or some combination of these and other methods.
+#KbdInteractiveAuthentication yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server


### PR DESCRIPTION
- Modify sshd_config to only listen to LAN interface
- Modify pf.conf for cleanliness and additional states
    - Antispoof now set WAN as well
    - Default behaviour is now `block drop log all`
    - Changed table `<icmp_abusers>` to `<badactors>` for future-proofing
    - Add max-src-conn-rate and max-src-conn for DNS, ICMP, and SSH
    - Add to `<badactors>` any source that exceeds ICMP and SSH limits